### PR TITLE
【Fixed】Feature/issues 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem 'seed-fu', '~> 2.3'
 # Authentication
 gem 'devise'
 
+gem 'rexml'
+
 group :development, :test do
   gem 'awesome_print'
   gem 'bullet'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,6 +441,7 @@ DEPENDENCIES
   rails-controller-testing
   rails-erd
   redcarpet (~> 3.5.1)
+  rexml
   rspec-parameterized
   rspec-rails
   rspec-retry

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -52,6 +52,7 @@ class TeamsController < ApplicationController
     @team.update(owner_id: params[:owner_id])
     @user = User.find(@team.owner_id)
     redirect_to team_path, notice: 'オーナー権限が移動しました!'
+    AssignMailer.assign_mail(@team.owner.email).deliver
   end
 
   private

--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -1,6 +1,6 @@
 class TeamsController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_team, only: %i[show edit update destroy]
+  before_action :set_team, only: %i[show edit update destroy assign_owner]
 
   def index
     @teams = Team.all
@@ -46,6 +46,12 @@ class TeamsController < ApplicationController
 
   def dashboard
     @team = current_user.keep_team_id ? Team.find(current_user.keep_team_id) : current_user.teams.first
+  end
+
+  def assign_owner
+    @team.update(owner_id: params[:owner_id])
+    @user = User.find(@team.owner_id)
+    redirect_to team_path, notice: 'オーナー権限が移動しました!'
   end
 
   private

--- a/app/mailers/assign_mailer.rb
+++ b/app/mailers/assign_mailer.rb
@@ -1,9 +1,8 @@
 class AssignMailer < ApplicationMailer
   default from: 'from@example.com'
 
-  def assign_mail(email, password)
+  def assign_mail(email)
     @email = email
-    @password = password
     mail to: @email, subject: I18n.t('views.messages.complete_registration')
   end
 end

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -41,7 +41,12 @@
                     <tr>
                       <td><%= image_tag 'default.jpg', size: '40x40' %></td>
                       <td><%= assign.user.email %></td>
-                      <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% if (current_user.id == assign.team.owner.id ) || ( current_user.id == assign.user.id ) %>
+                        <td><%= link_to I18n.t('views.button.delete'), team_assign_path(@team, assign), method: :delete, class: 'btn btn-sm btn-danger' %></td>
+                      <% end %>
+                      <% if current_user == assign.team.owner %>
+                        <td><%= link_to '権限譲渡', assign_owner_team_path(owner_id: assign.user_id), method: :post, class: 'btn btn-sm btn-success' %></td>
+                      <% end %>
                     </tr>
                   <% end %>
                 </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,9 @@ Rails.application.routes.draw do
         resources :comments
       end
     end
+    member do
+      post :assign_owner
+    end
   end
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?


### PR DESCRIPTION
#2

- Teamのリーダー（オーナー）が、Teamのshowページを開くと、各チームメンバーの「削除」ボタンの右隣に「権限移動」のボタンが出現するそのボタンを押すと、そのTeamのオーナーが選択したUserに変更される
- Teamのオーナーが変更されたら、新しくオーナーになったユーザーに通知メールが飛ぶ